### PR TITLE
Update version and remove private value for npm publishing

### DIFF
--- a/jschart/package.json
+++ b/jschart/package.json
@@ -1,11 +1,10 @@
 {
   "name": "jschart",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "This is a Javascript library that renders SVG charts.",
   "scripts": {
     "build": "webpack"
   },
-  "private": true,
   "author": "Karl Rister",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
In order to publish the npm registry, the project needs to
be public.