### PR TITLE
Remove ES6 features

### DIFF
--- a/jschart/index.js
+++ b/jschart/index.js
@@ -1,6 +1,6 @@
 const d3 = require("d3");
 const d3_queue = require("d3-queue");
-const { saveSvgAsPng } = require("save-svg-as-png");
+const saveSvgAsPng = require("save-svg-as-png");
 require("./index.css");
 
 function load_jschart_override_options() {
@@ -1047,7 +1047,7 @@ function load_json(chart, callback) {
   }
 
   if (chart.options.json_object !== undefined) {
-    let json = chart.options.json_object;
+    var json = chart.options.json_object;
     parse_json(json, chart, callback);
   } else {
     d3.json(chart.options.json_plotfile)
@@ -2859,14 +2859,14 @@ function build_chart(chart) {
     .text("Help");
 
   // make sure that the library was properly loaded prior to adding the "Save as PNG" link
-  if (typeof saveSvgAsPng == "function") {
+  if (typeof saveSvgAsPng.saveSvgAsPng == "function") {
     chart.chart.container
       .append("text")
       .classed("actionlabel middletext", true)
       .attr("x", (chart.dimensions.viewport_width / 4) * 2)
       .attr("y", -chart.dimensions.margin.top + 29)
       .on("click", function() {
-        saveSvgAsPng(this.ownerSVGElement, chart.chart_title + ".png", {
+        saveSvgAsPng.saveSvgAsPng(this.ownerSVGElement, chart.chart_title + ".png", {
           backgroundColor: "#FFFFFF"
         });
       })

--- a/jschart/package.json
+++ b/jschart/package.json
@@ -1,7 +1,13 @@
 {
   "name": "jschart",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "This is a Javascript library that renders SVG charts.",
+  "keywords": [
+    "chart", 
+    "time series",
+    "canvas"
+  ],
+  "homepage": "https://github.com/distributed-system-analysis/jschart",
   "scripts": {
     "build": "webpack"
   },


### PR DESCRIPTION
Presents the jschart library as is by removing the need to compile ES6 with babel. 