### PR TITLE
Address potential security vulnerability w/ axios

### DIFF
--- a/cdm-tests/package.json
+++ b/cdm-tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "EPL-1.0",
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": ">=0.21.1",
     "d3": "3.5.17",
     "jschart": "file:../jschart",
     "react": "^16.5.1",


### PR DESCRIPTION
See https://github.com/advisories/GHSA-4w2v-q235-vp99 ...

Vulnerable versions: `< 0.21.1`
Patched version: `0.21.1`

Axios NPM package `0.21.0` contains a Server-Side Request Forgery (SSRF) vulnerability where an attacker is able to bypass a proxy by providing a URL that responds with a redirect to a restricted host or IP address.